### PR TITLE
Update action.yml to use node20 instead of deprecated node12

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -11,5 +11,5 @@ outputs:
   uuid:
     description: 'the generated UUID.'
 runs:
-  using: 'node12'
+  using: 'node20'
   main: 'dist/index.js'

--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
-const uuidv1 = require('uuid/v1');
-const uuidv5 = require('uuid/v5');
+import { v4 as uuidv4 } from 'uuid';
+import { v5 as uuidv5 } from 'uuid';
 const core = require('@actions/core');
 
 async function run() {
@@ -8,7 +8,7 @@ async function run() {
     const namespace =
       core.getInput('namespace') || 'f9962f80-1514-11ea-bfe7-1f9e6cf0a044';
 
-    let uuid = uuidv1();
+    let uuid = uuidv4();
     if (name) {
       uuid = uuidv5(name, namespace);
     }

--- a/package.json
+++ b/package.json
@@ -1,18 +1,18 @@
 {
   "name": "uuid-action",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "description": "GitHub Action to generate UUIDs.",
   "main": "index.js",
   "license": "MIT",
-  "author": "@filipstefansson",
+  "author": "@radu-solomon-dnsf",
   "scripts": {
     "build": "ncc build index.js"
   },
   "dependencies": {
-    "@actions/core": "^1.2.6",
-    "uuid": "^3.3.3"
+    "@actions/core": "^1.11.0",
+    "uuid": "^10.0.0"
   },
   "devDependencies": {
-    "@zeit/ncc": "^0.20.5"
+    "@vercel/ncc": "^0.38.2"
   }
 }


### PR DESCRIPTION
Update the node from 12 to 20 and update to not use the Deprecating save-state and set-output commands as per

https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/
https://github.blog/changelog/2023-06-13-github-actions-all-actions-will-run-on-node16-instead-of-node12-by-default/ 